### PR TITLE
Store trained model in models for denoise_image function

### DIFF
--- a/topaz/commands/denoise.py
+++ b/topaz/commands/denoise.py
@@ -431,6 +431,8 @@ def main(args):
                 torch.save(model, path)
                 if use_cuda:
                     model.cuda()
+                    
+        models = [model]
 
     else: # load the saved model(s)
         models = []


### PR DESCRIPTION
Training denoising models cannot be completed because models is not defined when pretrained models are not used, and models is required for the denoise_image function.