### PR TITLE
Avoid pandas df.iterrows dtype conversion

### DIFF
--- a/topaz/commands/train.py
+++ b/topaz/commands/train.py
@@ -189,17 +189,17 @@ def cross_validation_split(k, fold, images, targets, random=np.random):
 
     test_images = [[]*len(images)]
     test_targets = [[]*len(targets)]
-    for _,row in validate_table.iterrows():
-        i = row['source']
-        j = row['image_name']
+    for row in validate_table.itertuples():
+        i = row.source
+        j = row.image_name
         test_images[i].append(images[i][j])
         test_targets[i].append(targets[i][j])
 
     train_images = [[]*len(images)]
     train_targets = [[]*len(targets)]
-    for _,row in train_table.iterrows():
-        i = row['source']
-        j = row['image_name']
+    for row in train_table.itertuples():
+        i = row.source
+        j = row.image_name
         train_images[i].append(images[i][j])
         train_targets[i].append(targets[i][j])
 


### PR DESCRIPTION
Super small fix: the pandas df.iterrows() method reverts ints to floats, but in this case the results are used as list indices and must remain ints. This was causing exceptions/errors for me when using k-fold cross validation. See the Note at https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.iterrows.html

Replaced with df.itertuples() which preserves dtypes (as per suggestion in that same Note).