### PR TITLE
Fix #177 with a --version output containing only a semver string

### DIFF
--- a/topaz/main.py
+++ b/topaz/main.py
@@ -55,7 +55,7 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
 
     import topaz
-    parser.add_argument('--version', action='version', version='TOPAZ '+topaz.__version__)
+    parser.add_argument('--version', action='version', version=topaz.__version__)
 
     import topaz.commands.train
     import topaz.commands.segment


### PR DESCRIPTION
I tested in a fresh conda environment that the output of `topaz --version` now matches something accepted by `semver.VersionInfo.isvalid()`.