### PR TITLE
Add Intel PyTorch extension

### DIFF
--- a/topaz/methods.py
+++ b/topaz/methods.py
@@ -7,6 +7,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
+try:
+    import intel_extension_for_pytorch as ipex
+except:
+    pass
 
 def autoencoder_loss(model, X):
     X = X.unsqueeze(1)
@@ -123,8 +127,7 @@ class GE_binomial:
         ## KL of w from the binomial distribution with pi
         log_binom = scipy.stats.binom.logpmf(np.arange(0,N+1),N,self.pi)
         log_binom = torch.from_numpy(log_binom).float()
-        if q_var.is_cuda:
-            log_binom = log_binom.cuda()
+        log_binom = log_binom.to(q_var.device)
         log_binom = Variable(log_binom)
 
         ge_penalty = -torch.sum(log_binom*q_discrete)

--- a/topaz/predict.py
+++ b/topaz/predict.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, print_function, division
 
 import torch
-
+try:
+    import intel_extension_for_pytorch as ipex
+except:
+    pass
 
 def batches(X, batch_size=1):
     batch = []
@@ -16,20 +19,19 @@ def batches(X, batch_size=1):
         yield batch
 
 
-def score_stream(model, images, use_cuda=False, batch_size=1):
+def score_stream(model, images, device='cpu', batch_size=1):
     with torch.no_grad():
         for x in batches(images, batch_size=batch_size):
             x = x.unsqueeze(1)
-            if use_cuda:
-                x = x.cuda()
+            x = x.to(device)
             logits = model(x).squeeze(1).cpu().numpy()
             for i in range(len(logits)):
                 yield logits[i]
 
 
-def score(model, images, use_cuda=False, batch_size=1):
+def score(model, images, device='cpu', batch_size=1):
     scores = []
-    for y in score_stream(model, images, use_cuda=use_cuda, batch_size=batch_size):
+    for y in score_stream(model, images, device=device, batch_size=batch_size):
         scores.append(y)
     return scores
 

--- a/topaz/stats.py
+++ b/topaz/stats.py
@@ -4,10 +4,13 @@ import numpy as np
 import scipy.stats
 
 import torch
-
+try:
+    import intel_extension_for_pytorch as ipex
+except:
+    pass
 
 def normalize(x, alpha=900, beta=1, num_iters=100, sample=1
-             , method='gmm', use_cuda=False, verbose=False):
+             , method='gmm', device='cpu', verbose=False):
     if method == 'affine':
         mu = x.mean()
         std = x.std()
@@ -32,7 +35,7 @@ def normalize(x, alpha=900, beta=1, num_iters=100, sample=1
 
     mu, std, pi, logp, mus, stds, pis, logps = norm_fit(x_sample, alpha=alpha, beta=beta
                                                        , scale=scale
-                                                       , num_iters=num_iters, use_cuda=use_cuda
+                                                       , num_iters=num_iters, device=device
                                                        , verbose=verbose)
 
     # normalize the data
@@ -57,7 +60,7 @@ def normalize(x, alpha=900, beta=1, num_iters=100, sample=1
 
 
 def norm_fit(x, alpha=900, beta=1, scale=1
-            , num_iters=100, use_cuda=False, verbose=False):
+            , num_iters=100, device='cpu', verbose=False):
     
     # try multiple initializations of pi
     pis = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.98, 1])
@@ -68,8 +71,7 @@ def norm_fit(x, alpha=900, beta=1, scale=1
     stds = np.zeros(len(pis))
 
     x = torch.from_numpy(x)
-    if use_cuda:
-        x = x.cuda()
+    x = x.to(device)
     
     for i in range(len(pis)):
         pi = pis[i]


### PR DESCRIPTION
This will add Intel(R) Extension for PyTorch which is for Intel(R) GPU support.
This needs Intel patched PyTorch and extension and one can refer https://intel.github.io/intel-extension-for-pytorch/index.html#installation?platform=gpu&version=v2.1.10%2Bxpu page for installation.

This contains the below changes.
- "import intel_extension_for_pytorch as ipex" is needed for Intel GPU and it is optional in Python code to make it work on platform which does not have this package installed.
- torch.xpu is replacement for torch.cuda and this is explicitly used when necessary.
- topaz/cuda.py is replaced by topaz/gpu.py file which is more generic.
- Most use_cuda=True function argument is replaced by device='cpu'.
- torch.\*.cuda() is replaced by torch.\*.to(device) where device could be 'cpu'|'cuda'|'xpu'.
- There is limitation in using torch.nn.Parallel on Intel GPU.
- ipex.optimize() is additional optimization on Intel GPU. This is added and commented out since not all configuration is supported as of now. This is for future usage.