### PR TITLE
feat: add argument seed to topaz normalize

### DIFF
--- a/topaz/commands/normalize.py
+++ b/topaz/commands/normalize.py
@@ -38,6 +38,7 @@ def add_arguments(parser=None):
     parser.add_argument('--format', dest='format_', default='mrc', help='image format(s) to write. choices are mrc, tiff, and png. images can be written in multiple formats by specifying each in a comma separated list, e.g. mrc,png would write mrc and png format images (default: mrc)')
     
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
+    parser.add_argument('--seed', default=0, type=int, help='seed to be used in the normalize process. default is 0 (random seed)')
 
     return parser
 
@@ -54,7 +55,7 @@ def main(args):
     num_workers = 0 if use_cuda else args.num_workers
 
     normalize_images(args.files, args.destdir, num_workers, args.scale, args.affine, args.niters, args.alpha, args.beta,
-                        args.sample, args.metadata, formats, use_cuda, args.verbose)
+                        args.sample, args.metadata, formats, use_cuda, args.verbose, seed=args.seed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi!

I noticed [here](https://github.com/tbepler/topaz?tab=readme-ov-file#normalization-topaz-normalize) mentions the seed argument, which was present in [v0.1.0](https://github.com/tbepler/topaz/blob/b26e4abbad58be37b7d57eda4e7ad4ed6f980d64/topaz/commands/preprocess.py#L28), is no [longer present](https://github.com/tbepler/topaz/blob/d6e57234f6aa4ec3af74ee754eb25181363caf54/topaz/commands/normalize.py#L15) in the latest version. This PR adds the seed arg back. With a specified non zero seed, I can now get the exact same output after multiple preprocess/normalize runs. Without it the outputs are not equivalent.